### PR TITLE
chore: add OS connector extension; install kubectl+helm

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,7 @@
 {
     "recommendations": [
-        "redhat.vscode-yaml",
         "redhat.ansible",
+        "redhat.vscode-openshift-connector",
         "ms-python.python",
         "ms-python.black-formatter"
     ]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+    "vs-kubernetes": {
+        "vscode-kubernetes.kubectl-path.linux": "/home/runner/.local/state/vs-kubernetes/tools/kubectl/kubectl",
+        "vscode-kubernetes.helm-path": "/home/runner/.local/state/vs-kubernetes/tools/helm/linux-amd64/helm",
+    }
+}


### PR DESCRIPTION
- Add redhat.vscode-openshift-connector as a recommended extension
- Update Dockerfile by installing kubectl and helm
- Add settings for vs-kubernetes extension

![screenshot-devspaces apps sandbox-m4 g2pi p1 openshiftapps com-2023 06 21-19_21_51](https://github.com/devspaces-samples/ansible-devspaces-demo/assets/1271546/6c4b2697-0808-4b3b-beb9-86282b4e23da)

To test changes follow the link https://devspaces.apps.sandbox-m4.g2pi.p1.openshiftapps.com/dashboard/#/https://github.com/svor/ansible-devspaces-demo/tree/devspaces-3-rhel-8
