### PR TITLE
feat: install k8s python module; use digest in platform's image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,13 @@ FROM quay.io/ansible/creator-ee@sha256:c89ecbcf47bfa956a2ed3c4939cd29a53298943c8
 
 ENV HOME=/home/runner
 
+# install kubernetes module required by molecule
+RUN pip3 install kubernetes
+
 ## kubectl
 RUN \
     microdnf install -y which && \
+    microdnf clean all && \
     curl -LO https://dl.k8s.io/release/`curl -LS https://dl.k8s.io/release/stable.txt`/bin/linux/amd64/kubectl && \
     chmod +x ./kubectl && \
     mv ./kubectl /usr/local/bin && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM quay.io/ansible/creator-ee@sha256:c89ecbcf47bfa956a2ed3c4939cd29a53298943c8
 ENV HOME=/home/runner
 
 # install kubernetes module required by molecule
-RUN pip3 install kubernetes
+RUN pip3 install kubernetes==26.1.0
 
 ## kubectl
 RUN \

--- a/roles/backup_file/molecule/default/molecule.yml
+++ b/roles/backup_file/molecule/default/molecule.yml
@@ -9,16 +9,7 @@ driver:
       connection: local
 platforms:
   - name: molecule-ubi8-init-1
-    image: registry.access.redhat.com/ubi8/ubi-init
-    workingDir: '/tmp'
-  - name: molecule-rhel8-python-39
-    image: registry.redhat.io/rhel8/python-39
-    workingDir: '/tmp'
-  - name: molecule-rhel8-python-38
-    image: registry.redhat.io/rhel8/python-38
-    workingDir: '/tmp'
-  - name: molecule-centos8-stream
-    image: quay.io/centos/centos:stream8
+    image: registry.access.redhat.com/ubi8/ubi-init@sha256:75cb1eb60b9636f8daa584c231db552c1de94006778e7224643804a696f04fad
     workingDir: '/tmp'
 provisioner:
   name: ansible


### PR DESCRIPTION
With this PR the image used by the devfile will be extended by installing kubernetes python module. 

Also it decreases the list of platforms that should use image with digest in the molecule.yaml file that makes the process of configuring AirGap environment more easily.

Related issue: https://issues.redhat.com/browse/CRW-4541  