### PR TITLE
chore: update node to 18.18.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN \
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash && \
 export NVM_DIR="$HOME/.nvm" && \
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-nvm install 18.15.0
-ENV VSCODE_NODEJS_RUNTIME_DIR="$HOME/.nvm/versions/node/v18.15.0/bin/"
+nvm install 18.18.0
+ENV VSCODE_NODEJS_RUNTIME_DIR="$HOME/.nvm/versions/node/v18.18.0/bin/"
 
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -39,8 +39,8 @@ RUN \
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash && \
 export NVM_DIR="$HOME/.nvm" && \
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
-nvm install 16.20.0
-ENV VSCODE_NODEJS_RUNTIME_DIR="$HOME/.nvm/versions/node/v16.20.0/bin/"
+nvm install 18.15.0
+ENV VSCODE_NODEJS_RUNTIME_DIR="$HOME/.nvm/versions/node/v18.15.0/bin/"
 
 # Set permissions on /etc/passwd and /home to allow arbitrary users to write
 RUN chgrp -R 0 /home && chmod -R g=u /etc/passwd /etc/group /home

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN \
     cd - && \
     rm -rf "${TEMP_DIR}"
 
-# nodejs 16 + VSCODE_NODEJS_RUNTIME_DIR are required on ubi9 based images
+# nodejs 18 + VSCODE_NODEJS_RUNTIME_DIR are required on ubi9 based images
 # until we fix https://github.com/eclipse/che/issues/21778
 # When fixed, we won't need this Dockerfile anymore.
 # c.f. https://github.com/che-incubator/che-code/pull/120


### PR DESCRIPTION
Backports changes from https://github.com/devspaces-samples/ansible-devspaces-demo/pull/9

-----------

Update node to 18.18.0 in ansible-creator-ee image because Che Code requires node >=18.15.x

To test that tasks a available with node 18, start a workspace by https://devspaces.apps.sandbox-stage.gb17.p1.openshiftapps.com/#/https://github.com/svor/ansible-devspaces-demo