### PR TITLE
Update base image; adapt the sample

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# quay.io/ansible/creator-ee:v0.18.0
-FROM quay.io/ansible/creator-ee@sha256:c89ecbcf47bfa956a2ed3c4939cd29a53298943c8db11eb35d20b9b939ba2a48
+# quay.io/ansible/creator-ee:v0.20.0
+FROM quay.io/ansible/creator-ee@sha256:72acf1476d32a7e56ec9045d8147eee010d8eecfc52590a3b8a7a620985696d4
 
 ENV HOME=/home/runner
 

--- a/collections/example/collection/roles/backup_file/molecule/default/molecule.yml
+++ b/collections/example/collection/roles/backup_file/molecule/default/molecule.yml
@@ -2,7 +2,7 @@
 dependency:
   name: galaxy
 driver:
-  name: delegated
+  name: default
   options:
     managed: true
     ansible_connection_options:


### PR DESCRIPTION
Some improvements during the investigation of https://issues.redhat.com/browse/CRW-4594

Update base image to **quay.io/ansible/creator-ee:v0.20.0**

- It allows to install **ansible-navigator:3.5.0** without errors.

- After applying new image molecule commands were failed with a message:

> ```
> CRITICAL Failed to find driver delegated. Please ensure that the driver is correctly installed.
> ```


- [x] The problem was fixed by changing driver's name to **default**:


![screenshot-devspaces apps ci-ln-r3995it-76ef8 aws-2 ci openshift org-2023 10 20-19_45_43](https://github.com/devspaces-samples/ansible-devspaces-demo/assets/1271546/cce5e6c1-76c8-469c-a07e-28f1c046f2c3)

**To test changes click the icon:** 
[![DS](https://louisville.edu/anthropology/images/click-me/image)](https://devspaces.apps.sandbox-stage.gb17.p1.openshiftapps.com/#/https://github.com/svor/ansible-devspaces-demo/tree/sv-test-pr-with-new-ee-image)

