### PR TITLE
feat:install ansible-navigator; add additional command to run ansible-navigator

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ FROM quay.io/ansible/creator-ee@sha256:72acf1476d32a7e56ec9045d8147eee010d8eecfc
 
 ENV HOME=/home/runner
 
-# install kubernetes module required by molecule
-RUN pip3 install kubernetes==26.1.0
+# install additional modules required by ansible
+COPY requirements.txt requirements.txt
+RUN pip3 install -r requirements.txt
 
 ## kubectl
 RUN \

--- a/devfile.yaml
+++ b/devfile.yaml
@@ -37,6 +37,17 @@ commands:
         kind: run
         isDefault: true
       component: tooling-container
+  - id: ansible-navigator
+    exec:
+      label: "Ansible-Navigator: Start ansible-navigator"
+      commandLine: |
+        if [ ! -d "$HOME/.cache/ansible-navigator" ]; then
+          mkdir -p "$HOME/.cache/ansible-navigator"
+        fi
+        cp /usr/local/lib/python3.11/site-packages/ansible_navigator/data/catalog_collections.py $HOME/.cache/ansible-navigator 
+        ansible-navigator --ee false
+      workingDir: ${PROJECTS_ROOT}/ansible-devspaces-demo
+      component: tooling-container
 events:
   postStart:
     - "oc-install"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+kubernetes==26.1.0
+ansible-navigator==3.5.0


### PR DESCRIPTION
This PR provides next changes:
- install ansible-navigator into the image
- move additional installed python modules into requirements.txt file
- add a command to run ansible-navigator

Since ansible-creator image provides all requirements for ansible-navigator (ansible-core along with a set of Ansible collections), we run it with `--ee false` parameter to avoid pulling a pre-built container image.

**Related issue:** 
https://issues.redhat.com/browse/CRW-4594

**You can find steps how to try ansible-navigator with Dev Spaces in the video:** 

https://github.com/devspaces-samples/ansible-devspaces-demo/assets/1271546/512b635e-9946-4a19-84e7-c864ade94400


**You can test the changes by clicking the icon:** 
[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://devspaces.apps.sandbox-stage.gb17.p1.openshiftapps.com/#/https://github.com/svor/ansible-devspaces-demo/tree/sv-test-pr-navigator-no-ee)
