### PR TITLE
Add podman scenario to molecule

### DIFF
--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/converge.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/converge.yml
@@ -1,0 +1,34 @@
+---
+- name: Fail if molecule group is missing
+  hosts: localhost
+  tasks:
+    - name: Print some info
+      ansible.builtin.debug:
+        msg: "{{ groups }}"
+
+    - name: Assert group existence
+      ansible.builtin.assert:
+        that: "'molecule' in groups"
+        fail_msg: |
+          molecule group was not found inside inventory groups: {{ groups }}
+
+- name: Converge roles
+  hosts: molecule
+  # We disable gather facts because it would fail due to our container not
+  # having python installed. This will not prevent use from running 'raw'
+  # commands. Most molecule users are expected to use containers that already
+  # have python installed in order to avoid notable delays installing it.
+  gather_facts: false
+  tasks:
+    - name: Check uname
+      ansible.builtin.raw: uname -a
+      register: result
+      changed_when: false
+
+    - name: Print some info
+      ansible.builtin.assert:
+        that: result.stdout | regex_search("^Linux")
+
+    - name: Include role
+      ansible.builtin.include_role:
+        name: example.web.install_apache

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/create.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/create.yml
@@ -1,0 +1,78 @@
+---
+- name: Create
+  hosts: localhost
+  gather_facts: false
+  vars:
+    molecule_inventory:
+      all:
+        hosts: {}
+        molecule: {}
+  tasks:
+    - name: Create a container
+      containers.podman.podman_container:
+        name: "{{ item.name }}"
+        image: "{{ item.image }}"
+        state: started
+        command: sleep 1d
+        # bash -c "while true; do sleep 10000; done"
+        log_driver: json-file
+      register: result
+      loop: "{{ molecule_yml.platforms }}"
+
+    - name: Fail if container is not running
+      when: >
+        item.container.State.ExitCode != 0 or
+        not item.container.State.Running
+      ansible.builtin.include_tasks:
+        file: tasks/create-fail.yml
+      loop: "{{ result.results }}"
+      loop_control:
+        label: "{{ item.container.Name }}"
+
+    - name: Add container to molecule_inventory
+      vars:
+        inventory_partial_yaml: |
+          all:
+            children:
+              molecule:
+                hosts:
+                  "{{ item.name }}":
+                    ansible_connection: containers.podman.podman
+      ansible.builtin.set_fact:
+        molecule_inventory: >
+          {{ molecule_inventory | combine(inventory_partial_yaml | from_yaml, recursive=true) }}
+      loop: "{{ molecule_yml.platforms }}"
+      loop_control:
+        label: "{{ item.name }}"
+
+    - name: Dump molecule_inventory
+      ansible.builtin.copy:
+        content: |
+          {{ molecule_inventory | to_yaml }}
+        dest: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        mode: "0600"
+
+    - name: Force inventory refresh
+      ansible.builtin.meta: refresh_inventory
+
+    - name: Fail if molecule group is missing
+      ansible.builtin.assert:
+        that: "'molecule' in groups"
+        fail_msg: |
+          molecule group was not found inside inventory groups: {{ groups }}
+      run_once: true # noqa: run-once[task]
+
+# we want to avoid errors like "Failed to create temporary directory"
+- name: Validate that inventory was refreshed
+  hosts: molecule
+  gather_facts: false
+  tasks:
+    - name: Check uname
+      ansible.builtin.raw: uname -a
+      register: result
+      changed_when: false
+
+    - name: Display uname info
+      ansible.builtin.debug:
+        msg: "{{ result.stdout }}"
+

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/destroy.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/destroy.yml
@@ -1,0 +1,26 @@
+---
+- name: Destroy molecule containers
+  hosts: molecule
+  gather_facts: false
+  tasks:
+    - name: Stop and remove container
+      delegate_to: localhost
+      containers.podman.podman_container:
+        name: "{{ inventory_hostname }}"
+        state: absent
+        rm: true
+    - name: Remove potentially stopped container
+      delegate_to: localhost
+      ansible.builtin.command:
+        cmd: podman container rm --ignore {{ inventory_hostname }}
+      changed_when: false
+
+- name: Remove dynamic molecule inventory
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Remove dynamic inventory file
+      ansible.builtin.file:
+        path: "{{ molecule_ephemeral_directory }}/inventory/molecule_inventory.yml"
+        state: absent
+

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/molecule.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/molecule.yml
@@ -1,0 +1,19 @@
+---
+dependency:
+  name: galaxy
+  options:
+    requirements-file: requirements.yml
+
+platforms:
+  - name: ubi8
+    image: registry.access.redhat.com/ubi8/ubi-init:latest
+  - name: ubi9
+    image: registry.access.redhat.com/ubi9/ubi-init:latest
+
+driver:
+  options:
+    managed: False
+    login_cmd_template: "podman exec -ti {instance} bash"
+    ansible_connection_options:
+      ansible_connection: podman
+

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/requirements.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/requirements.yml
@@ -1,0 +1,3 @@
+---
+collections:
+  - containers.podman

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/tasks/create-fail.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/tasks/create-fail.yml
@@ -1,0 +1,15 @@
+---
+- name: Retrieve container log
+  ansible.builtin.command:
+    cmd: >-
+      {% raw %}
+      podman logs
+      {% endraw %}
+      {{ item.stdout_lines[0] }}
+    # podman inspect --format='{{.HostConfig.LogConfig.Path}}'
+  changed_when: false
+  register: logfile_cmd
+
+- name: Display container log
+  ansible.builtin.fail:
+    msg: "{{ logfile_cmd.stderr }}"

--- a/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/verify.yml
+++ b/collections/ansible_collections/sample_namespace/sample_collection/extensions/molecule/podman/verify.yml
@@ -1,0 +1,14 @@
+---
+- name: Verify
+  hosts: molecule
+  gather_facts: false
+
+  tasks:
+    - name: Gather package information
+      ansible.builtin.package_facts:
+
+    - name: Assert apache package is installed
+      ansible.builtin.assert:
+        that:
+          - "'httpd' in ansible_facts.packages"
+


### PR DESCRIPTION
This is a simple podman based scenario. It comes directly from the [molecule documentation](https://ansible.readthedocs.io/projects/molecule/examples/podman/).

The scenario currently does not work because it's expecting a basic collection (example.web) to install apache. I wasn't sure how to proceed with that. I can add that collection as well if you'd like. Just let me know how to proceed.