### PR TITLE
set devfile schemaVersion 2.2.2

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -1,4 +1,4 @@
-schemaVersion: 2.2.0
+schemaVersion: 2.2.2
 metadata:
   name: ansible-demo
 components:


### PR DESCRIPTION
Updates devfile's schemaVersion to 2.2.2

Related issue: https://github.com/eclipse/che/issues/21985

![screenshot-devspaces apps sandbox-stage gb17 p1 openshiftapps com-2024 02 01-15_13_42](https://github.com/devspaces-samples/ansible-devspaces-demo/assets/1271546/47a8b277-74c3-4e7f-a478-e59ab1e900c1)
