### PR TITLE
fix: update ordering of commands

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -44,20 +44,20 @@ commands:
         isDefault: true
       component: tooling-container
 
-  - id: molecule-verify
+  - id: molecule-converge
     exec:
-      label: "3.Molecule: run the verification against the test pod"
-      commandLine: 'source $HOME/.bashrc && molecule verify'
+      label: "3.Molecule: apply the role to the pod"
+      commandLine: 'source $HOME/.bashrc && molecule converge'
       workingDir: ${PROJECTS_ROOT}/ansible-devspaces-demo/collections/ansible_collections/sample_namespace/sample_collection/extensions
       group:
         kind: run
         isDefault: true
       component: tooling-container
 
-  - id: molecule-converge
+  - id: molecule-verify
     exec:
-      label: "4.Molecule: apply the role to the pod"
-      commandLine: 'source $HOME/.bashrc && molecule converge'
+      label: "4.Molecule: run the verification against the test pod"
+      commandLine: 'source $HOME/.bashrc && molecule verify'
       workingDir: ${PROJECTS_ROOT}/ansible-devspaces-demo/collections/ansible_collections/sample_namespace/sample_collection/extensions
       group:
         kind: run


### PR DESCRIPTION
Changes commands' ordering: set **molecule converge** command before **molecule verify** command 

![screenshot-nimbusweb me-2024 03 04-11_59_39](https://github.com/devspaces-samples/ansible-devspaces-demo/assets/1271546/cf068597-9126-49c6-9a74-d0d83f141166)


Related issue: https://issues.redhat.com/browse/CRW-5661

**You can test the changes by clicking the icon:** 
[![Contribute](https://www.eclipse.org/che/contribute.svg)](https://devspaces.apps.sandbox-stage.gb17.p1.openshiftapps.com/#/https://github.com/devspaces-samples/ansible-devspaces-demo/tree/sv-CRW-5661)
