### PR TITLE
add preStop command to destroy pod

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -86,3 +86,6 @@ commands:
         ansible-navigator --ee false
       workingDir: ${PROJECTS_ROOT}/ansible-devspaces-demo
       component: tooling-container
+events:
+  preStop:
+    - "molecule-destroy"


### PR DESCRIPTION
Adds a preStop command to terminate the pod used by Molecule when the workspace is stopped

How to test:

1/ Create a workspace from https://github.com/devspaces-samples/ansible-devspaces-demo/tree/sv-preStop
2/ Run **6.Molecule: run the full molecule test** command
3/ Check that test pod molecule-ubi8-python-1 is created on OS console:
![screenshot-nimbusweb me-2024 08 09-16_41_33](https://github.com/user-attachments/assets/4588c12c-dd44-4925-ae45-0ab147422410)
4/ Stop the workspace
5/ Check that the test pod is terminated automatically  

Related issue: https://issues.redhat.com/browse/CRW-6871
