### PR TITLE
add preStop command to destroy pod

### DIFF
--- a/devfile.yaml
+++ b/devfile.yaml
@@ -86,3 +86,6 @@ commands:
         ansible-navigator --ee false
       workingDir: ${PROJECTS_ROOT}/ansible-devspaces-demo
       component: tooling-container
+events:
+  preStop:
+    - "molecule-destroy"


### PR DESCRIPTION
Backported changes from https://github.com/devspaces-samples/ansible-devspaces-demo/pull/33

Related issue: https://issues.redhat.com/browse/CRW-6871